### PR TITLE
Add IntelliJ Light style.

### DIFF
--- a/options/list-styles.js
+++ b/options/list-styles.js
@@ -244,6 +244,7 @@ const FullStyleList = [
     { file: "base16/xcode-dusk",                    name: "XCode Dusk" },
     { file: "xt256",                                name: "xt256" },
     { file: "base16/zenburn",                       name: "Zenburn" },
+    { file: "intellij-light",                       name: "IntelliJ Light" },
 ];
 /* eslint-enable no-multi-spaces */
 


### PR DESCRIPTION
Adds IntelliJ Light style to the list-styles.js. This style has been introduced
in highlight.js and need to be listed here in order to properly build the
project.