### PR TITLE
Add IntelliJ Light style.

### DIFF
--- a/options/list-styles.js
+++ b/options/list-styles.js
@@ -136,6 +136,7 @@ const FullStyleList = [
     { file: "base16/ir-black",                      name: "IR Black (Base16)" },
     { file: "base16/icy-dark",                      name: "Icy Dark" },
     { file: "idea",                                 name: "Idea" },
+    { file: "intellij-light",                       name: "IntelliJ Light" },
     { file: "isbl-editor-dark",                     name: "ISBL Editor Dark" },
     { file: "isbl-editor-light",                    name: "ISBL Editor Light" },
     { file: "base16/isotope",                       name: "Isotope" },


### PR DESCRIPTION
Adds IntelliJ Light style to the list-styles.js. This style has been introduced
in highlight.js and need to be listed here in order to properly build the
project.