### PR TITLE
Fix invisible checkboxes

### DIFF
--- a/options/common.inc.css
+++ b/options/common.inc.css
@@ -435,7 +435,6 @@ html|a:hover:active,
 /* Checkboxes and radio buttons */
 
 html|input[type="checkbox"] {
-  appearance: none;
   width: 20px;
   height: 20px;
   padding: 1px;


### PR DESCRIPTION
The checkboxes would not change the color and have the check icon when selected. Removing the line that messes with the `appearance` attribute of the checkboxes appears to solve the issue.