### PR TITLE
Do not colorize commit logs

### DIFF
--- a/scripts/coloring.js
+++ b/scripts/coloring.js
@@ -14,7 +14,8 @@ const coloring = {
         const preNodes = document.querySelectorAll("body > div > pre");
 
         for (const pre of preNodes) {
-            let i, j = -1;
+            let i;
+            let j = -1;
 
             for (i = 0; i < pre.childNodes.length && j < 0; i++) {
                 if (pre.childNodes[i].nodeName === "#text") {
@@ -26,7 +27,7 @@ const coloring = {
                 }
             }
             if (j >= 0) {
-                pre.childNodes[i - 1].splitText(j + '---'.length);
+                pre.childNodes[i - 1].splitText(j + "---".length);
             }
             for (; i < pre.childNodes.length; i++) {
                 if (pre.childNodes[i].nodeName === "#text") {

--- a/scripts/coloring.js
+++ b/scripts/coloring.js
@@ -14,7 +14,21 @@ const coloring = {
         const preNodes = document.querySelectorAll("body > div > pre");
 
         for (const pre of preNodes) {
-            for (let i = 0; i < pre.childNodes.length; i++) {
+            let i, j = -1;
+
+            for (i = 0; i < pre.childNodes.length && j < 0; i++) {
+                if (pre.childNodes[i].nodeName === "#text") {
+                    /*
+                     * man git-format-patch: The log message and the patch are
+                     * separated by a line with a three-dash line.
+                     */
+                    j = pre.childNodes[i].textContent.search(/^---$/m);
+                }
+            }
+            if (j >= 0) {
+                pre.childNodes[i - 1].splitText(j + '---'.length);
+            }
+            for (; i < pre.childNodes.length; i++) {
                 if (pre.childNodes[i].nodeName === "#text") {
                     const span = document.createElement("SPAN");
 


### PR DESCRIPTION
Patch e-mails typically include a commit log as a header, which may contain arbitrary text including patterns that highlight.js can interpret as a diff. I have typically encountered this when a commit log line starts with a commandline option or a bullet point.

I am not sure if people actually send raw diffs without a commit log, so maybe this should be handled with a bit more care to handle these.